### PR TITLE
Fixes during step-by-step reading README.md

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -4,6 +4,10 @@ Makefile*
 # VS project files
 humimit.*
 humimitd.*
+*.sdf
+*.opensdf
+*.suo
+*.vcxproj*
 *.tmp
 
 # MacOS generated files

--- a/README.md
+++ b/README.md
@@ -25,14 +25,14 @@ TEST_CLASS_DEFINITION(Test2){
 After this you need implement `GUITestsLauncher`:
 ```cpp
 #include <core/GUITestsLauncher.h>
-class MyGUITestsLauncher: public GUITestsLauncher
+class MyGUITestsLauncher: public HI:GUITestsLauncher
 {
 public:
     MyGUITestsLauncher();
 };
 ```
 ```cpp
-MyGUITestsLauncher::MyGUITestsLauncher(): GUITestsLauncher()
+MyGUITestsLauncher::MyGUITestsLauncher(): HI:GUITestsLauncher()
 {
     guiTestBase.registerTest(new Test1());
     guiTestBase.registerTest(new Test2());

--- a/src/core/GUITest.h
+++ b/src/core/GUITest.h
@@ -79,11 +79,11 @@ typedef QList<GUITest*> GUITests;
 #define SUITENAME(className) QString(GUI_TEST_SUITE)
 
 #define TEST_CLASS_DECLARATION(className) \
-    class className : public GUITest { \
+    class className : public HI::GUITest { \
     public: \
-        className () : GUITest(TESTNAME(className), SUITENAME(className)){} \
+        className () : HI::GUITest(TESTNAME(className), SUITENAME(className)){} \
     protected: \
-        virtual void run(GUITestOpStatus &os); \
+        virtual void run(HI::GUITestOpStatus &os); \
     };
 
 #define TEST_CLASS_DECLARATION_SET_TIMEOUT(className, timeout) \
@@ -95,7 +95,7 @@ typedef QList<GUITest*> GUITests;
     };
 
 #define TEST_CLASS_DEFINITION(className) \
-    void className::run(GUITestOpStatus &os)
+    void className::run(HI::GUITestOpStatus &os)
 
 
 } //HI

--- a/src/core/GUITestsLauncher.h
+++ b/src/core/GUITestsLauncher.h
@@ -15,10 +15,10 @@ public:
 public slots:
     virtual void sl_runTest();
     virtual void sl_onTestFinished();
+protected:
+	GUITestBase guiTestBase;
 private:
-    GUITestBase guiTestBase;
     GUITestOpStatus os;
-
 };
 
 }


### PR DESCRIPTION
0) After compiling using Visual Studio 2013, there are lots of VS temporary/project files
1) Users may not prefer to have "using namespace HI" in their programs, so all #defines should use HI namespace implicitly
2)

```
MyGUITestsLauncher::MyGUITestsLauncher(): GUITestsLauncher()
{
    guiTestBase.registerTest(new Test1());
    guiTestBase.registerTest(new Test2());
}
```

To have access to guiTestBase from a derived MyGUITestsLauncher of GUITestsLauncher, guiTestBase must be at least protected
