### PR TITLE
Gitignore updated - visual studio project files

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,6 +13,10 @@ moc_*
 # VS project files
 humimit.*
 humimitd.*
+*.sdf
+*.opensdf
+*.suo
+*.vcxproj*
 *.tmp
 
 # MacOS generated files


### PR DESCRIPTION
After compiling using Visual Studio 2013, there are lots of VS temporary/project files
