### PR TITLE
Using HI namespace in defines

### DIFF
--- a/src/core/GUITest.h
+++ b/src/core/GUITest.h
@@ -79,23 +79,23 @@ typedef QList<GUITest*> GUITests;
 #define SUITENAME(className) QString(GUI_TEST_SUITE)
 
 #define TEST_CLASS_DECLARATION(className) \
-    class className : public GUITest { \
+    class className : public HI::GUITest { \
     public: \
-        className () : GUITest(TESTNAME(className), SUITENAME(className)){} \
+        className () : HI::GUITest(TESTNAME(className), SUITENAME(className)){} \
     protected: \
-        virtual void run(GUITestOpStatus &os); \
+        virtual void run(HI::GUITestOpStatus &os); \
     };
 
 #define TEST_CLASS_DECLARATION_SET_TIMEOUT(className, timeout) \
-    class className : public GUITest { \
+    class className : public HI::GUITest { \
     public: \
-        className () : GUITest(TESTNAME(className), SUITENAME(className), timeout){} \
+        className () : HI::GUITest(TESTNAME(className), SUITENAME(className), timeout){} \
     protected: \
-        virtual void run(GUITestOpStatus &os); \
+        virtual void run(HI::GUITestOpStatus &os); \
     };
 
 #define TEST_CLASS_DEFINITION(className) \
-    void className::run(GUITestOpStatus &os)
+    void className::run(HI::GUITestOpStatus &os)
 
 
 } //HI


### PR DESCRIPTION
Users may not prefer to have "using namespace HI" in their programs, so all #defines should use HI namespace implicitly
